### PR TITLE
Standardize Card to String conversion to use UTF-8 suit symbols

### DIFF
--- a/src/core/card.rs
+++ b/src/core/card.rs
@@ -182,10 +182,10 @@ impl Suit {
     /// Returns `None` for characters not representing a Suit. The input is case-insensitive.
     pub fn from_char(c: char) -> Option<Suit> {
         match c.to_ascii_lowercase() {
-            'h' => Some(Self::Heart),
-            'c' => Some(Self::Club),
-            'd' => Some(Self::Diamond),
-            's' => Some(Self::Spade),
+            'h' | '♥' => Some(Self::Heart),
+            'c' | '♣' => Some(Self::Club),
+            'd' | '♦' => Some(Self::Diamond),
+            's' | '♠' => Some(Self::Spade),
             _ => None,
         }
     }
@@ -299,7 +299,7 @@ impl From<i32> for Card {
 impl TryFrom<String> for Card {
     type Error = String;
     fn try_from(s: String) -> Result<Self, Self::Error> {
-        if s.len() != 2 {
+        if s.chars().count() != 2 {
             return Err(format!(
                 r#"Card string "{}" is not exactly a length of 2"#,
                 s
@@ -402,6 +402,14 @@ mod tests {
         for card_str in ["AH", "ah"] {
             let card = Card::from_str(card_str).unwrap();
             assert_eq!(card.to_int(), 49);
+        }
+    }
+
+    #[test]
+    fn conversion_from_suit_symbols() {
+        for index in 1..=52 {
+            let card = Card::from(index);
+            assert_eq!(Card::from_str(&card.to_string()).unwrap(), card);
         }
     }
 

--- a/src/core/card.rs
+++ b/src/core/card.rs
@@ -332,7 +332,7 @@ impl TryFrom<String> for Card {
 
 impl From<Card> for String {
     fn from(c: Card) -> Self {
-        format!("{}{}", c.value.get_char(), c.suit.get_char())
+        c.to_string()
     }
 }
 

--- a/src/core/card.rs
+++ b/src/core/card.rs
@@ -179,7 +179,8 @@ impl Suit {
 
     /// Parses a character, returning the corresponding Suit if valid.
     ///
-    /// Returns `None` for characters not representing a Suit. The input is case-insensitive.
+    /// The input is either a case-insensitive letter, or the UTF-8 character representing the suit.
+    /// Returns `None` for characters not representing a Suit.
     pub fn from_char(c: char) -> Option<Suit> {
         match c.to_ascii_lowercase() {
             'h' | '♥' => Some(Self::Heart),


### PR DESCRIPTION
This will allow the `Card`s to be parsed back from their `.to_string()` output.